### PR TITLE
Add C++ prototype skeleton

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.10)
+project(OpenFrontPrototype)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+find_package(SDL2 REQUIRED)
+include_directories(${SDL2_INCLUDE_DIRS})
+
+add_executable(OpenFrontPrototype src/main.cpp)
+
+target_link_libraries(OpenFrontPrototype SDL2::SDL2)

--- a/cpp/README.md
+++ b/cpp/README.md
@@ -1,0 +1,16 @@
+# OpenFront C++ Prototype
+
+This directory contains a simple SDL-based prototype for a future C++ version of OpenFront.
+
+## Building
+
+Ensure you have `SDL2` and `CMake` installed, then run:
+
+```bash
+mkdir build
+cd build
+cmake ..
+make
+```
+
+The resulting executable `OpenFrontPrototype` will open a basic window as a starting point for further development.

--- a/cpp/src/main.cpp
+++ b/cpp/src/main.cpp
@@ -1,0 +1,44 @@
+#include <SDL2/SDL.h>
+#include <iostream>
+
+int main(int argc, char* argv[]) {
+    if (SDL_Init(SDL_INIT_VIDEO) != 0) {
+        std::cerr << "SDL_Init Error: " << SDL_GetError() << std::endl;
+        return 1;
+    }
+
+    SDL_Window* win = SDL_CreateWindow("OpenFront Prototype", 100, 100, 800, 600, SDL_WINDOW_SHOWN);
+    if (win == nullptr) {
+        std::cerr << "SDL_CreateWindow Error: " << SDL_GetError() << std::endl;
+        SDL_Quit();
+        return 1;
+    }
+
+    SDL_Renderer* ren = SDL_CreateRenderer(win, -1, SDL_RENDERER_ACCELERATED | SDL_RENDERER_PRESENTVSYNC);
+    if (ren == nullptr) {
+        SDL_DestroyWindow(win);
+        std::cerr << "SDL_CreateRenderer Error: " << SDL_GetError() << std::endl;
+        SDL_Quit();
+        return 1;
+    }
+
+    SDL_SetRenderDrawColor(ren, 0, 0, 0, 255);
+    SDL_RenderClear(ren);
+    SDL_RenderPresent(ren);
+
+    bool quit = false;
+    SDL_Event e;
+    while (!quit) {
+        while (SDL_PollEvent(&e)) {
+            if (e.type == SDL_QUIT) {
+                quit = true;
+            }
+        }
+        SDL_Delay(16);
+    }
+
+    SDL_DestroyRenderer(ren);
+    SDL_DestroyWindow(win);
+    SDL_Quit();
+    return 0;
+}


### PR DESCRIPTION
## Summary
- start C++ prototype using SDL
- include basic CMake build file
- document build steps

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68405ce5cdbc832ca499fa1974c26476