### PR TITLE
Add spawn and movement mechanics to C++ prototype

### DIFF
--- a/cpp/README.md
+++ b/cpp/README.md
@@ -14,8 +14,8 @@ make
 ```
 
 The resulting executable `OpenFrontPrototype` opens a small demo window and draws
-a province grid from `maps/sample.map`. Each character in the file represents a
-terrain type (`P` plains, `F` forest, `M` mountain, `W` water).
+a province grid from one of the bin maps in `../resources/maps`. Each
+character in the file represents a terrain type.
 
 Run the prototype from the `build` directory:
 
@@ -23,9 +23,8 @@ Run the prototype from the `build` directory:
 ./OpenFrontPrototype
 ```
 
-Use the arrow keys to move the red player army around the map. Provinces you
-enter become owned by the player and are tinted red. Press the space bar to
-generate a path to the blue enemy army and watch your units move automatically.
-The enemy now has a simple AI: if it is active, it will plot a path towards the
-player and chase them each tick.
+When the prototype starts you have ten seconds to click a starting tile on the
+map. Your army of 500 units will spawn on that province. After placing the army
+use the arrow keys to move around. Moving into a new province claims it for the
+player and reduces your remaining units.
 

--- a/cpp/src/main.cpp
+++ b/cpp/src/main.cpp
@@ -11,7 +11,7 @@ int main(int argc, char* argv[]) {
 
     GameMap map = GameMap::loadFromBin("../resources/maps/PangaeaMini.bin");
 
-    const int tileSize = 2;
+    const int tileSize = 16; // larger tiles so we can see clicking locations
     int windowWidth = map.width() * tileSize;
     int windowHeight = map.height() * tileSize;
 
@@ -31,6 +31,11 @@ int main(int argc, char* argv[]) {
         SDL_Quit();
         return 1;
     }
+
+    GameMap::TileRef playerPos = 0;
+    int playerUnits = 0;
+    bool spawnPlaced = false;
+    Uint32 startTime = SDL_GetTicks();
 
     auto drawMap = [&]() {
         SDL_SetRenderDrawColor(ren, 0, 0, 0, 255);
@@ -58,6 +63,16 @@ int main(int argc, char* argv[]) {
             SDL_Rect rect{map.x(r) * tileSize, map.y(r) * tileSize,
                           tileSize, tileSize};
             SDL_RenderFillRect(ren, &rect);
+            if (map.ownerID(r) == 1) {
+                SDL_SetRenderDrawColor(ren, 192, 64, 64, 120);
+                SDL_RenderFillRect(ren, &rect);
+            }
+        }
+        if (spawnPlaced) {
+            SDL_SetRenderDrawColor(ren, 255, 0, 0, 255);
+            SDL_Rect army{map.x(playerPos) * tileSize, map.y(playerPos) * tileSize,
+                         tileSize, tileSize};
+            SDL_RenderFillRect(ren, &army);
         }
         SDL_RenderPresent(ren);
     };
@@ -69,8 +84,52 @@ int main(int argc, char* argv[]) {
         while (SDL_PollEvent(&e)) {
             if (e.type == SDL_QUIT) {
                 quit = true;
+            } else if (!spawnPlaced && e.type == SDL_MOUSEBUTTONDOWN &&
+                       e.button.button == SDL_BUTTON_LEFT) {
+                Uint32 elapsed = SDL_GetTicks() - startTime;
+                if (elapsed < 10000) {
+                    int mx = e.button.x / tileSize;
+                    int my = e.button.y / tileSize;
+                    if (map.isValidCoord(mx, my)) {
+                        auto ref = map.ref(mx, my);
+                        if (map.isLand(ref)) {
+                            spawnPlaced = true;
+                            playerPos = ref;
+                            playerUnits = 500;
+                            map.setOwnerID(ref, 1);
+                            std::cout << "Spawn placed at (" << mx << "," << my
+                                      << ") with 500 units\n";
+                        }
+                    }
+                }
+            } else if (spawnPlaced && e.type == SDL_KEYDOWN) {
+                int dx = 0, dy = 0;
+                switch (e.key.keysym.sym) {
+                    case SDLK_UP:    dy = -1; break;
+                    case SDLK_DOWN:  dy = 1;  break;
+                    case SDLK_LEFT:  dx = -1; break;
+                    case SDLK_RIGHT: dx = 1;  break;
+                    default: break;
+                }
+                if (dx != 0 || dy != 0) {
+                    int nx = map.x(playerPos) + dx;
+                    int ny = map.y(playerPos) + dy;
+                    if (map.isValidCoord(nx, ny)) {
+                        auto next = map.ref(nx, ny);
+                        if (map.isLand(next)) {
+                            playerPos = next;
+                            if (map.ownerID(next) != 1 && playerUnits > 0) {
+                                --playerUnits;
+                            }
+                            map.setOwnerID(next, 1);
+                            std::string title = "Units: " + std::to_string(playerUnits);
+                            SDL_SetWindowTitle(win, title.c_str());
+                        }
+                    }
+                }
             }
         }
+        drawMap();
         SDL_Delay(16);
     }
 


### PR DESCRIPTION
## Summary
- enable selecting a spawn tile within ten seconds
- spawn an army with 500 units
- move using arrow keys and capture provinces while losing units
- document new usage in `cpp/README.md`

## Testing
- `cmake ..`
- `make -j$(nproc)`
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841af13a918832c817be468a77fe7fb