### PR TITLE
Add zoomable map view to CPP prototype

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -14,6 +14,7 @@ add_executable(OpenFrontPrototype
     src/MapLoader.cpp
     src/GameMap.cpp
     src/GameMapLoader.cpp
+    src/MapView.cpp
 )
 
 

--- a/cpp/src/MapView.cpp
+++ b/cpp/src/MapView.cpp
@@ -1,0 +1,68 @@
+#include "MapView.h"
+#include <algorithm>
+
+MapView::MapView(const GameMap& map, int windowWidth, int windowHeight, int tileSize)
+    : map_(map), windowWidth_(windowWidth), windowHeight_(windowHeight),
+      tileSize_(tileSize), offsetX_(0), offsetY_(0) {}
+
+void MapView::clampOffsets() {
+    int maxX = std::max(0, map_.width() - windowWidth_ / tileSize_);
+    int maxY = std::max(0, map_.height() - windowHeight_ / tileSize_);
+    if (offsetX_ < 0) offsetX_ = 0;
+    if (offsetY_ < 0) offsetY_ = 0;
+    if (offsetX_ > maxX) offsetX_ = maxX;
+    if (offsetY_ > maxY) offsetY_ = maxY;
+}
+
+void MapView::pan(int dx, int dy) {
+    offsetX_ += dx;
+    offsetY_ += dy;
+    clampOffsets();
+}
+
+void MapView::zoom(int delta) {
+    int newSize = tileSize_ + delta;
+    newSize = std::clamp(newSize, 1, 64);
+    if (newSize != tileSize_) {
+        tileSize_ = newSize;
+        clampOffsets();
+    }
+}
+
+void MapView::render(SDL_Renderer* renderer) {
+    SDL_SetRenderDrawColor(renderer, 0, 0, 0, 255);
+    SDL_RenderClear(renderer);
+
+    int tilesX = windowWidth_ / tileSize_;
+    int tilesY = windowHeight_ / tileSize_;
+    for (int y = 0; y < tilesY; ++y) {
+        int mapY = y + offsetY_;
+        if (mapY >= map_.height()) break;
+        for (int x = 0; x < tilesX; ++x) {
+            int mapX = x + offsetX_;
+            if (mapX >= map_.width()) break;
+            GameMap::TileRef r = map_.ref(mapX, mapY);
+            switch (map_.terrainType(r)) {
+                case TerrainType::Plains:
+                    SDL_SetRenderDrawColor(renderer, 136, 192, 80, 255);
+                    break;
+                case TerrainType::Highland:
+                    SDL_SetRenderDrawColor(renderer, 160, 160, 80, 255);
+                    break;
+                case TerrainType::Mountain:
+                    SDL_SetRenderDrawColor(renderer, 200, 200, 200, 255);
+                    break;
+                case TerrainType::Lake:
+                    SDL_SetRenderDrawColor(renderer, 64, 160, 224, 255);
+                    break;
+                case TerrainType::Ocean:
+                default:
+                    SDL_SetRenderDrawColor(renderer, 0, 96, 192, 255);
+                    break;
+            }
+            SDL_Rect rect{x * tileSize_, y * tileSize_, tileSize_, tileSize_};
+            SDL_RenderFillRect(renderer, &rect);
+        }
+    }
+    SDL_RenderPresent(renderer);
+}

--- a/cpp/src/MapView.h
+++ b/cpp/src/MapView.h
@@ -1,0 +1,22 @@
+#pragma once
+#include <SDL2/SDL.h>
+#include "GameMap.h"
+
+class MapView {
+public:
+    MapView(const GameMap& map, int windowWidth, int windowHeight, int tileSize = 2);
+
+    void pan(int dx, int dy);
+    void zoom(int delta);
+    void render(SDL_Renderer* renderer);
+
+private:
+    const GameMap& map_;
+    int windowWidth_;
+    int windowHeight_;
+    int tileSize_;
+    int offsetX_;
+    int offsetY_;
+
+    void clampOffsets();
+};

--- a/cpp/src/main.cpp
+++ b/cpp/src/main.cpp
@@ -2,6 +2,7 @@
 #include <iostream>
 #include "GameMap.h"
 #include "GameMapLoader.h"
+#include "MapView.h"
 
 int main(int argc, char* argv[]) {
     if (SDL_Init(SDL_INIT_VIDEO) != 0) {
@@ -11,9 +12,8 @@ int main(int argc, char* argv[]) {
 
     GameMap map = GameMap::loadFromBin("../resources/maps/PangaeaMini.bin");
 
-    const int tileSize = 2;
-    int windowWidth = map.width() * tileSize;
-    int windowHeight = map.height() * tileSize;
+    const int windowWidth = 800;
+    const int windowHeight = 600;
 
     SDL_Window* win = SDL_CreateWindow("OpenFront Prototype", 100, 100,
                                        windowWidth, windowHeight, SDL_WINDOW_SHOWN);
@@ -32,45 +32,40 @@ int main(int argc, char* argv[]) {
         return 1;
     }
 
-    auto drawMap = [&]() {
-        SDL_SetRenderDrawColor(ren, 0, 0, 0, 255);
-        SDL_RenderClear(ren);
-        int total = map.width() * map.height();
-        for (int r = 0; r < total; ++r) {
-            switch (map.terrainType(r)) {
-                case TerrainType::Plains:
-                    SDL_SetRenderDrawColor(ren, 136, 192, 80, 255);
-                    break;
-                case TerrainType::Highland:
-                    SDL_SetRenderDrawColor(ren, 160, 160, 80, 255);
-                    break;
-                case TerrainType::Mountain:
-                    SDL_SetRenderDrawColor(ren, 200, 200, 200, 255);
-                    break;
-                case TerrainType::Lake:
-                    SDL_SetRenderDrawColor(ren, 64, 160, 224, 255);
-                    break;
-                case TerrainType::Ocean:
-                default:
-                    SDL_SetRenderDrawColor(ren, 0, 96, 192, 255);
-                    break;
-            }
-            SDL_Rect rect{map.x(r) * tileSize, map.y(r) * tileSize,
-                          tileSize, tileSize};
-            SDL_RenderFillRect(ren, &rect);
-        }
-        SDL_RenderPresent(ren);
-    };
+    MapView view(map, windowWidth, windowHeight, 2);
+    view.render(ren);
 
     bool quit = false;
     SDL_Event e;
-    drawMap();
     while (!quit) {
         while (SDL_PollEvent(&e)) {
             if (e.type == SDL_QUIT) {
                 quit = true;
+            } else if (e.type == SDL_KEYDOWN) {
+                switch (e.key.keysym.sym) {
+                    case SDLK_EQUALS:
+                    case SDLK_PLUS:
+                        view.zoom(1);
+                        break;
+                    case SDLK_MINUS:
+                        view.zoom(-1);
+                        break;
+                    case SDLK_UP:
+                        view.pan(0, -1);
+                        break;
+                    case SDLK_DOWN:
+                        view.pan(0, 1);
+                        break;
+                    case SDLK_LEFT:
+                        view.pan(-1, 0);
+                        break;
+                    case SDLK_RIGHT:
+                        view.pan(1, 0);
+                        break;
+                }
             }
         }
+        view.render(ren);
         SDL_Delay(16);
     }
 


### PR DESCRIPTION
## Summary
- implement new `MapView` class for rendering with panning and zooming
- update `main.cpp` to use `MapView` and handle input
- include `MapView.cpp` in the CMake build

## Testing
- `cmake ..`
- `make -j4`
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841afb0025c832c9ff10713f127112d